### PR TITLE
Clearer instructions for soldering control pads

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,11 @@ All parts were sourced from AliExpress and added up to **just over $10** (last c
 
 Make sure to:
 
-* Solder the pads on the **back of the PCM5102A** (as shown below)
+* Solder the 4 control pads on the **back of the PCM5102A** (also shown below):
+  * H1L -> L
+  * H2L -> L
+  * H3L -> H
+  * H4L -> L
 * Solder the bridge near **SCK on the front** (some boards come pre-soldered)
 
 <img src="https://github.com/user-attachments/assets/17d6b71f-2928-4bff-ac34-9cff48638098" />


### PR DESCRIPTION
I wasn't really paying attention to the README and missed soldering the control pads H1L, H2L, H3L, H4L. Took me a while to figure this out because instructions were a bit vague ("solder the pads on the back").

Hope that helps someone else that had the Sendspin Zero working flawlessly but having it on soft mute (when H3L is not on H).